### PR TITLE
Move pulseaudio format-muted out of icon block

### DIFF
--- a/waybar/config
+++ b/waybar/config
@@ -139,8 +139,8 @@
         "scroll-step": 10,
         "format": "{icon}",
         "tooltip-format": "{volume}%",
+        "format-muted": " ",
         "format-icons": {
-            "format-muted": " ",
             "default": [
                 " ",
                 " ",


### PR DESCRIPTION
The format-muted tag is not valid inside the format-icons block, and therefore did not work.